### PR TITLE
Tweak: alphabetic order, added missing previews & updated links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,89 +2,122 @@
 
 Wallpapers for CachyOS
 
+#### Abstract
+![abstract](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Abstract.png)
+
+#### BlueFeathers
+![bluefeathers](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/BlueFeathers.png)
+
+#### BlueLady
+![bluelady](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/BlueLady.png)
+
+#### BlueNekoLady
+![bluenekolady](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/BlueNekoLady.png)
+
+#### Cachy depths 5K
+![cachydepths5k](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Cachy%20depths%205K.png)
+
+#### Cachy_Topography
+![cachy_topography](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Cachy_Topography.jpg)
+
+#### Cachy_Topography1
+![cachy_topography1](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Cachy_Topography1.jpg)
+
+#### Cachy_Topography2
+![cachy_topography2](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Cachy_Topography2.jpg)
+
+#### Cachy_Topography3
+![cachy_topography3](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Cachy_Topography3.jpg)
+
+#### Cachy_Topography4
+![cachy_topography4](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Cachy_Topography4.jpg)
+
+#### Cachy_Topography5
+![cachy_topography5](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Cachy_Topography5.jpg)
+
+#### Cachy_Topography6
+![cachy_topography6](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Cachy_Topography6.jpg)
+
+#### CachyAdventure169
+![cachyadventure169](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/CachyAdventure169.png)
+
+#### Cachyadventure219
+![cachyadventure219](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Cachyadventure219.png)
+
+#### Cachygalaxy99
+![cachygalaxy99](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/cachygalaxy00.jpg)
+
+#### CachyOS_GreenSpace
+![cachyos_greenspace](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/CachyOS_GreenSpace.png)
+
+#### CachyOS_Moon
+![cachyos_moon](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/CachyOS_Moon.jpg)
+
+#### Cachysurf3
+![cachysurf](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/cachysurf3.jpg)
+
+#### Cachysurf4
+![cachysurf4](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/cachysurf4.jpg)
+
+#### DarkStreaks
+![darkstreaks](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/DarkStreaks.png)
+
+#### Dimensions
+![dimensions](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Dimensions.png)
+
+#### Dracula
+![dracula](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Dracula.png)
+
+#### EmeraldNekoLady
+![emeraldnekolady](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/EmeraldNekoLady.png)
+
+#### GreenFeathers
+![greenfeathers](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/GreenFeathers.png)
+
+#### GreenNekoLady
+![greennekolady](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/GreenNekoLady.png)
+
+#### Limine-splash
+![limine-splash](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/limine-splash.png)
+
+#### Lines
+![lines](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Lines.png)
+
+#### Liquid
+![liquid](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Liquid.png)
+
+#### Metal
+![metal](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Metal.png)
+
 #### North
 ![north](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/north.png)
+
+#### OrangeFeathers
+![orangefeathers](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/OrangeFeathers.png)
+
+#### Paper
+![paper](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/paper.png)
+
+#### PinkLady
+![pinklady](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/PinkLady.png)
+
+#### PurpleFeathers
+![purplefeathers](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/PurpleFeathers.png)
+
+#### RedNekoLady
+![rednekolady](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/RedNekoLady.png)
+
+#### Skyscraper
+![skyscraper](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Skyscraper.png)
+
+#### Spectrum
+![spectrum](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Spectrum.png)
+
+#### Splash
+![splash](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/splash.png)
 
 #### Wave
 ![abstractwave](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/wave.png)
 
 #### Wave2 Dark
 ![abstractwave](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/wave2.png)
-
-#### Abstract
-![abstract](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Abstract.png)
-
-#### BlueFeathers
-![bluefeathers](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/BlueFeathers.png)
-
-#### BlueLady
-![bluelady](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/BlueLady.png)
-
-#### BlueNekoLady
-![bluenekolady](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/BlueNekoLady.png)
-
-#### Cachy depths 5K
-![cachydepths5k](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Cachy%20depths%205K.png)
-
-#### CachyAdventure169
-![cachyadventure169](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/CachyAdventure169.png)
-
-#### Cachyadventure219
-![cachyadventure219](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Cachyadventure219.png)
-
-#### DarkStreaks
-![darkstreaks](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/DarkStreaks.png)
-
-#### Dimensions
-![dimensions](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Dimensions.png)
-
-#### Dracula
-![dracula](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Dracula.png)
-
-#### GreenFeathers
-![greenfeathers](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/GreenFeathers.png)
-
-#### EmeraldNekoLady
-![emeraldnekolady](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/EmeraldNekoLady.png)
-
-#### GreenNekoLady
-![greennekolady](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/GreenNekoLady.png)
-
-#### Lines
-![lines](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Lines.png)
-
-#### Liquid
-![liquid](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Liquid.png)
-
-#### Metal
-![metal](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Metal.png)
-
-#### OrangeFeathers
-![orangefeathers](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/OrangeFeathers.png)
-
-#### PinkLady
-![pinklady](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/PinkLady.png)
-
-#### PurpleFeathers
-![purplefeathers](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/PurpleFeathers.png)
-
-#### RedNekoLady
-![rednekolady](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/RedNekoLady.png)
-
-#### Skyscraper
-![skyscraper](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Skyscraper.png)
-
-#### Spectrum
-![spectrum](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Spectrum.png)
-
-#### cachysurf3
-![cachysurf](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/cachysurf3.jpg)
-
-#### cachysurf4
-![cachysurf4](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/cachysurf4.jpg)
-
-#### paper
-![paper](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/paper.png)
-
-#### splash
-![splash](https://github.com/birbkeks/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/splash.png)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Wallpapers for CachyOS
 ![cachyadventure219](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/Cachyadventure219.png)
 
 #### Cachygalaxy99
-![cachygalaxy99](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/cachygalaxy00.jpg)
+![cachygalaxy99](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/cachygalaxy99.jpg)
 
 #### CachyOS_GreenSpace
 ![cachyos_greenspace](https://github.com/CachyOS/cachyos-wallpapers/blob/develop/usr/share/wallpapers/cachyos-wallpapers/CachyOS_GreenSpace.png)


### PR DESCRIPTION
Tweak: Tweaked the README.md to display the broken and/or missing previews.

For convenience the order of the wallpapers have been put in an alphabetic order besides that the 'links' to a user called: 'birbkeks' have been updated to the user: 'CachyOS' since this might have caused the broken/missing previews.